### PR TITLE
Fix Layer1 evaluation and add class imbalance weights

### DIFF
--- a/Layer 1- Rapid Anomaly Screener (Autoencoder).py
+++ b/Layer 1- Rapid Anomaly Screener (Autoencoder).py
@@ -126,8 +126,14 @@ def train_final_model(data: dict, best_params: dict):
     best_thr = thr[np.argmax(f1_scores)]
 
     test_tensor = torch.from_numpy(X_test).float().to(DEVICE)
-    recon_test = model(test_tensor)
-    test_mse = torch.mean((test_tensor - recon_test) ** 2, dim=1).cpu().numpy()
+    with torch.no_grad():
+        recon_test = model(test_tensor)
+        test_mse = (
+            torch.mean((test_tensor - recon_test) ** 2, dim=1)
+            .detach()
+            .cpu()
+            .numpy()
+        )
 
     test_df = data["test_df"].copy()
     test_df["Layer1_Reconstruction_Error"] = test_mse


### PR DESCRIPTION
## Summary
- compute fraud and billing error class weights during dataset loading
- wrap Layer 1 test inference in `torch.no_grad()` and detach before converting to NumPy

## Testing
- `python -m py_compile data_utils.py 'Layer 1- Rapid Anomaly Screener (Autoencoder).py'`
- `python - <<'PY'
import torch
import numpy as np
from torch import nn
model = nn.Sequential(nn.Linear(2,2))
X_test = np.random.rand(3,2)
test_tensor = torch.from_numpy(X_test).float()
with torch.no_grad():
    recon_test = model(test_tensor)
    test_mse = (
        torch.mean((test_tensor - recon_test)**2, dim=1)
        .detach()
        .cpu()
        .numpy()
    )
print(test_mse)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e65583300832e838ea02dd00bf5b1